### PR TITLE
feat: ability to add guests via app.cal.com/bookings

### DIFF
--- a/apps/web/components/dialog/AddGuestsDialog.tsx
+++ b/apps/web/components/dialog/AddGuestsDialog.tsx
@@ -1,0 +1,107 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import { z } from "zod";
+
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  MultiEmail,
+  Icon,
+  showToast,
+} from "@calcom/ui";
+
+interface IAddGuestsDialog {
+  isOpenDialog: boolean;
+  setIsOpenDialog: Dispatch<SetStateAction<boolean>>;
+  bookingId: number;
+}
+
+export const AddGuestsDialog = (props: IAddGuestsDialog) => {
+  const { t } = useLocale();
+  const ZAddGuestsInputSchema = z.array(z.string().email()).refine((emails) => {
+    const uniqueEmails = new Set(emails);
+    return uniqueEmails.size === emails.length;
+  });
+  const { isOpenDialog, setIsOpenDialog, bookingId } = props;
+  const utils = trpc.useUtils();
+  const [multiEmailValue, setMultiEmailValue] = useState<string[]>([""]);
+  const [isInvalidEmail, setIsInvalidEmail] = useState(false);
+
+  const addGuestsMutation = trpc.viewer.bookings.addGuests.useMutation({
+    onSuccess: async () => {
+      showToast(t("guests_added"), "success");
+      setIsOpenDialog(false);
+      setMultiEmailValue([""]);
+      utils.viewer.bookings.invalidate();
+    },
+    onError: (err) => {
+      const message = `${err.data?.code}: ${t(err.message)}`;
+      showToast(message || t("unable_to_add_guests"), "error");
+    },
+  });
+
+  const handleAdd = () => {
+    if (multiEmailValue.length === 0) {
+      return;
+    }
+    const validationResult = ZAddGuestsInputSchema.safeParse(multiEmailValue);
+    if (validationResult.success) {
+      addGuestsMutation.mutate({ bookingId, guests: multiEmailValue });
+    } else {
+      setIsInvalidEmail(true);
+    }
+  };
+
+  return (
+    <Dialog open={isOpenDialog} onOpenChange={setIsOpenDialog}>
+      <DialogContent enableOverflow>
+        <div className="flex flex-row space-x-3">
+          <div className="bg-subtle flex h-10 w-10 flex-shrink-0 justify-center rounded-full ">
+            <Icon name="user-plus" className="m-auto h-6 w-6" />
+          </div>
+          <div className="w-full pt-1">
+            <DialogHeader title={t("additional_guests")} />
+            <MultiEmail
+              label={t("add_emails")}
+              value={multiEmailValue}
+              readOnly={false}
+              setValue={setMultiEmailValue}
+            />
+
+            {isInvalidEmail && (
+              <div className="my-4 flex text-sm text-red-700">
+                <div className="flex-shrink-0">
+                  <Icon name="triangle-alert" className="h-5 w-5" />
+                </div>
+                <div className="ml-3">
+                  <p className="font-medium">{t("emails_must_be_unique_valid")}</p>
+                </div>
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button
+                onClick={() => {
+                  setMultiEmailValue([""]);
+                  setIsInvalidEmail(false);
+                  setIsOpenDialog(false);
+                }}
+                type="button"
+                color="secondary">
+                {t("cancel")}
+              </Button>
+              <Button data-testid="add_members" loading={addGuestsMutation.isPending} onClick={handleAdd}>
+                {t("add")}
+              </Button>
+            </DialogFooter>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -1,0 +1,174 @@
+import EventManager from "@calcom/core/EventManager";
+import dayjs from "@calcom/dayjs";
+import { sendAddGuestsEmails } from "@calcom/emails";
+import { parseRecurringEvent } from "@calcom/lib";
+import { getTranslation } from "@calcom/lib/server";
+import { getUsersCredentials } from "@calcom/lib/server/getUsersCredentials";
+import { isTeamAdmin, isTeamOwner } from "@calcom/lib/server/queries/teams";
+import { prisma } from "@calcom/prisma";
+import type { CalendarEvent } from "@calcom/types/Calendar";
+
+import { TRPCError } from "@trpc/server";
+
+import type { TrpcSessionUser } from "../../../trpc";
+import type { TAddGuestsInputSchema } from "./addGuests.schema";
+
+type AddGuestsOptions = {
+  ctx: {
+    user: NonNullable<TrpcSessionUser>;
+  };
+  input: TAddGuestsInputSchema;
+};
+export const addGuestsHandler = async ({ ctx, input }: AddGuestsOptions) => {
+  const { user } = ctx;
+  const { bookingId, guests } = input;
+
+  const booking = await prisma.booking.findFirst({
+    where: {
+      id: bookingId,
+    },
+    include: {
+      attendees: true,
+      eventType: true,
+      destinationCalendar: true,
+      references: true,
+      user: {
+        include: {
+          destinationCalendar: true,
+          credentials: true,
+        },
+      },
+    },
+  });
+
+  if (!booking) throw new TRPCError({ code: "NOT_FOUND", message: "booking_not_found" });
+
+  const isTeamAdminOrOwner =
+    (await isTeamAdmin(user.id, booking.eventType?.teamId ?? 0)) &&
+    (await isTeamOwner(user.id, booking.eventType?.teamId ?? 0));
+
+  const isOrganizer = booking.userId === user.id;
+
+  const isAttendee = !!booking.attendees.find((attendee) => attendee.email === user.email);
+
+  if (!isTeamAdminOrOwner && !isOrganizer && !isAttendee) {
+    throw new TRPCError({ code: "FORBIDDEN", message: "you_do_not_have_permission" });
+  }
+
+  const organizer = await prisma.user.findFirstOrThrow({
+    where: {
+      id: booking.userId || 0,
+    },
+    select: {
+      name: true,
+      email: true,
+      timeZone: true,
+      locale: true,
+    },
+  });
+
+  const blacklistedGuestEmails = process.env.BLACKLISTED_GUEST_EMAILS
+    ? process.env.BLACKLISTED_GUEST_EMAILS.split(",").map((email) => email.toLowerCase())
+    : [];
+
+  const uniqueGuests = guests.filter(
+    (guest) =>
+      !booking.attendees.some((attendee) => guest === attendee.email) &&
+      !blacklistedGuestEmails.includes(guest)
+  );
+
+  if (uniqueGuests.length === 0)
+    throw new TRPCError({ code: "BAD_REQUEST", message: "emails_must_be_unique_valid" });
+
+  const guestsFullDetails = uniqueGuests.map((guest) => {
+    return {
+      name: "",
+      email: guest,
+      timeZone: organizer.timeZone,
+      locale: organizer.locale,
+    };
+  });
+
+  const bookingAttendees = await prisma.booking.update({
+    where: {
+      id: bookingId,
+    },
+    include: {
+      attendees: true,
+    },
+    data: {
+      attendees: {
+        createMany: {
+          data: guestsFullDetails,
+        },
+      },
+    },
+  });
+
+  const attendeesListPromises = bookingAttendees.attendees.map(async (attendee) => {
+    return {
+      name: attendee.name,
+      email: attendee.email,
+      timeZone: attendee.timeZone,
+      language: {
+        translate: await getTranslation(attendee.locale ?? "en", "common"),
+        locale: attendee.locale ?? "en",
+      },
+    };
+  });
+
+  const attendeesList = await Promise.all(attendeesListPromises);
+  const tOrganizer = await getTranslation(organizer.locale ?? "en", "common");
+  const videoCallReference = booking.references.find((reference) => reference.type.includes("_video"));
+
+  const evt: CalendarEvent = {
+    title: booking.title || "",
+    type: (booking.eventType?.title as string) || booking?.title || "",
+    description: booking.description || "",
+    startTime: booking.startTime ? dayjs(booking.startTime).format() : "",
+    endTime: booking.endTime ? dayjs(booking.endTime).format() : "",
+    organizer: {
+      email: booking?.userPrimaryEmail ?? organizer.email,
+      name: organizer.name ?? "Nameless",
+      timeZone: organizer.timeZone,
+      language: { translate: tOrganizer, locale: organizer.locale ?? "en" },
+    },
+    attendees: attendeesList,
+    uid: booking.uid,
+    recurringEvent: parseRecurringEvent(booking.eventType?.recurringEvent),
+    location: booking.location,
+    destinationCalendar: booking?.destinationCalendar
+      ? [booking?.destinationCalendar]
+      : booking?.user?.destinationCalendar
+      ? [booking?.user?.destinationCalendar]
+      : [],
+    seatsPerTimeSlot: booking.eventType?.seatsPerTimeSlot,
+    seatsShowAttendees: booking.eventType?.seatsShowAttendees,
+  };
+
+  if (videoCallReference) {
+    evt.videoCallData = {
+      type: videoCallReference.type,
+      id: videoCallReference.meetingId,
+      password: videoCallReference?.meetingPassword,
+      url: videoCallReference.meetingUrl,
+    };
+  }
+
+  const credentials = await getUsersCredentials(ctx.user);
+
+  const eventManager = new EventManager({
+    ...user,
+    credentials: [...credentials],
+  });
+
+  await eventManager.updateCalendarAttendees(evt, booking);
+
+  try {
+    await sendAddGuestsEmails(evt, guests);
+  } catch (err) {
+    console.log("Error sending AddGuestsEmails");
+  }
+
+  return { message: "Guests added" };
+};

--- a/packages/trpc/server/routers/viewer/bookings/addGuests.schema.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const ZAddGuestsInputSchema = z.object({
+  bookingId: z.number(),
+  guests: z.array(z.string().email()),
+});
+
+export type TAddGuestsInputSchema = z.infer<typeof ZAddGuestsInputSchema>;


### PR DESCRIPTION
## Summary
- Added ability to add guests to existing bookings via the web application
- Implemented AddGuestsDialog component for guest management UI
- Created TRPC handler and schema for adding guests functionality
- Added email validation and duplicate checking

## Changes Made
- Created `AddGuestsDialog.tsx` component with email input validation
- Added `addGuests.handler.ts` with booking guest management logic
- Added `addGuests.schema.ts` with input validation schema
- Integrated guest addition workflow with existing booking system

## Test plan
- [ ] Test adding valid email addresses as guests
- [ ] Test validation of duplicate emails
- [ ] Test validation of invalid email formats
- [ ] Test permission checks for different user roles
- [ ] Test calendar event updates when guests are added

🤖 Generated with [Claude Code](https://claude.ai/code)