### PR TITLE
Remove password reset data from response

### DIFF
--- a/pages/api/auth/forgot-password.ts
+++ b/pages/api/auth/forgot-password.ts
@@ -69,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       text: message,
     });
 
-    return res.status(201).json({ message: "Reset Requested", data: passwordRequest });
+    return res.status(201).json({ message: "Reset Requested" });
   } catch (reason) {
     console.error(reason);
     return res.status(500).json({ message: "Unable to create password reset request" });


### PR DESCRIPTION
## Summary
- Remove sensitive password reset data from API response
- Improve security by not exposing internal reset request details  
- Clean up response payload to only include necessary information

## Changes Made
- Removed password reset data from forgot-password API response  
- Updated response format to be more secure and user-friendly
- Prevents potential information disclosure through API responses

## Test plan
- [ ] Test forgot password flow still works correctly
- [ ] Verify sensitive data is no longer exposed in responses
- [ ] Test email delivery functionality remains intact
- [ ] Confirm error handling works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)