### PR TITLE
SMS workflow reminder retry count tracking

### DIFF
--- a/packages/features/ee/workflows/api/scheduleSMSReminders.ts
+++ b/packages/features/ee/workflows/api/scheduleSMSReminders.ts
@@ -28,10 +28,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   //delete all scheduled sms reminders where scheduled date is past current date
   await prisma.workflowReminder.deleteMany({
     where: {
-      method: WorkflowMethods.SMS,
-      scheduledDate: {
-        lte: dayjs().toISOString(),
-      },
+      OR: [
+        {
+          method: WorkflowMethods.SMS,
+          scheduledDate: {
+            lte: dayjs().toISOString(),
+          },
+        },
+        {
+          retryCount: {
+            gt: 1,
+          },
+        },
+      ],
     },
   });
 
@@ -44,8 +53,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         lte: dayjs().add(7, "day").toISOString(),
       },
     },
-    select,
-  })) as PartialWorkflowReminder[];
+    select: {
+      ...select,
+      retryCount: true,
+    },
+  })) as (PartialWorkflowReminder & { retryCount: number })[];
 
   if (!unscheduledReminders.length) {
     res.json({ ok: true });
@@ -163,9 +175,26 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
               referenceId: scheduledSMS.sid,
             },
           });
+        } else {
+          await prisma.workflowReminder.update({
+            where: {
+              id: reminder.id,
+            },
+            data: {
+              retryCount: reminder.retryCount + 1,
+            },
+          });
         }
       }
     } catch (error) {
+      await prisma.workflowReminder.update({
+        where: {
+          id: reminder.id,
+        },
+        data: {
+          retryCount: reminder.retryCount + 1,
+        },
+      });
       console.log(`Error scheduling SMS with error ${error}`);
     }
   }

--- a/packages/prisma/migrations/20240508134359_add_retry_count_to_workflow_reminder/migration.sql
+++ b/packages/prisma/migrations/20240508134359_add_retry_count_to_workflow_reminder/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkflowReminder" ADD COLUMN     "retryCount" INTEGER NOT NULL DEFAULT 0;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -997,6 +997,7 @@ model WorkflowReminder {
   cancelled           Boolean?
   seatReferenceId     String?
   isMandatoryReminder Boolean?        @default(false)
+  retryCount          Int             @default(0)
 
   @@index([bookingUid])
   @@index([workflowStepId])


### PR DESCRIPTION
## Summary
- Add retry count tracking to workflow reminders
- Implement SMS reminder retry logic with count limits
- Update database schema with retryCount field
- Enhance SMS scheduling API with retry mechanisms
- Add proper error handling for failed SMS deliveries

## Test plan
- [ ] Test SMS reminder retry logic with various failure scenarios
- [ ] Verify retry count tracking across workflow steps
- [ ] Test maximum retry limit enforcement
- [ ] Validate database schema migration for retryCount
- [ ] Test SMS delivery failure recovery mechanisms

🤖 Generated with [Claude Code](https://claude.ai/code)